### PR TITLE
Fixed StackOverflowError when recursively visit object's field. 

### DIFF
--- a/src/main/java/org/jboss/libra/Libra.java
+++ b/src/main/java/org/jboss/libra/Libra.java
@@ -25,7 +25,6 @@ import org.jboss.libra.util.ReflectionLibraVisitor;
 import org.jboss.libra.util.VisitationException;
 
 import java.lang.instrument.Instrumentation;
-import java.util.LinkedList;
 
 /**
  * The Scales of Astraea with which objects can be weighed.
@@ -40,12 +39,12 @@ public class Libra {
     }
 
     public static long getDeepObjectSize(Object obj) throws LibraException {
-        return getDeepObjectSize(obj, ReflectionLibraVisitor.INSTANCE);
+        return getDeepObjectSize(obj, new ReflectionLibraVisitor());
     }
 
     public static long getDeepObjectSize(Object obj, LibraVisitor visitor) throws LibraException {
         try {
-            return visitor.visit(LibraObjectVisitor.INSTANCE, obj, new LinkedList<Object>());
+            return visitor.visit(LibraObjectVisitor.INSTANCE, obj);
         } catch (VisitationException e) {
             throw new LibraException(e);
         }

--- a/src/main/java/org/jboss/libra/Libra.java
+++ b/src/main/java/org/jboss/libra/Libra.java
@@ -25,6 +25,7 @@ import org.jboss.libra.util.ReflectionLibraVisitor;
 import org.jboss.libra.util.VisitationException;
 
 import java.lang.instrument.Instrumentation;
+import java.util.LinkedList;
 
 /**
  * The Scales of Astraea with which objects can be weighed.
@@ -44,7 +45,7 @@ public class Libra {
 
     public static long getDeepObjectSize(Object obj, LibraVisitor visitor) throws LibraException {
         try {
-            return visitor.visit(LibraObjectVisitor.INSTANCE, obj);
+            return visitor.visit(LibraObjectVisitor.INSTANCE, obj, new LinkedList<Object>());
         } catch (VisitationException e) {
             throw new LibraException(e);
         }

--- a/src/main/java/org/jboss/libra/util/ContextVisitor.java
+++ b/src/main/java/org/jboss/libra/util/ContextVisitor.java
@@ -21,9 +21,11 @@
  */
 package org.jboss.libra.util;
 
+import java.util.LinkedList;
+
 /**
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
 public interface ContextVisitor<R, C, T> {
-    R visit(C context, T target) throws VisitationException;
+    R visit(C context, T target, LinkedList<Object> parentChine) throws VisitationException;
 }

--- a/src/main/java/org/jboss/libra/util/ContextVisitor.java
+++ b/src/main/java/org/jboss/libra/util/ContextVisitor.java
@@ -21,11 +21,9 @@
  */
 package org.jboss.libra.util;
 
-import java.util.LinkedList;
-
 /**
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
 public interface ContextVisitor<R, C, T> {
-    R visit(C context, T target, LinkedList<Object> parentChine) throws VisitationException;
+    R visit(C context, T target) throws VisitationException;
 }

--- a/src/main/java/org/jboss/libra/util/ReflectionLibraVisitor.java
+++ b/src/main/java/org/jboss/libra/util/ReflectionLibraVisitor.java
@@ -31,10 +31,15 @@ import org.jboss.libra.LibraVisitor;
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
 public class ReflectionLibraVisitor implements LibraVisitor {
-    public static final ReflectionLibraVisitor INSTANCE = new ReflectionLibraVisitor();
+    //public static final ReflectionLibraVisitor INSTANCE = new ReflectionLibraVisitor();
 
     @Override
-    public Long visit(Visitor<Long, Object> visitor, Object obj, LinkedList<Object> parentChine) throws VisitationException {
+    public Long visit(Visitor<Long, Object> visitor, Object obj) throws VisitationException {
+        return visit(visitor, obj, new LinkedList<Object>());
+    }
+    
+    
+    private Long visit(Visitor<Long, Object> visitor, Object obj, LinkedList<Object> parentChine) throws VisitationException {
         final Class<?> cls = obj.getClass();
         long size = visitor.visit(obj);
         try {


### PR DESCRIPTION
Fixed StackOverflowError when recursively visit object's field. When
ReflectionLibraVisitor.visit(...) calculates size of an object, it
recursively goes through all its fields. If object contains a HashMap
which contains itself, a loop is formed.  I add a LinkedList to member
all processed fields to avoid the loop.
